### PR TITLE
Fix default value and usage of stranded parameter

### DIFF
--- a/python3/HTSeq/features.py
+++ b/python3/HTSeq/features.py
@@ -254,7 +254,7 @@ def make_feature_genomicarrayofsets(
         feature_type=None,
         feature_query=None,
         additional_attributes=None,
-        stranded='no',
+        stranded=False,
         verbose=False,
         ):
     """Organize a sequence of Feature objects into a GenomicArrayOfSets.
@@ -326,7 +326,7 @@ def make_feature_genomicarrayofsets(
                     raise ValueError(
                             "Feature %s does not contain a '%s' attribute" %
                             (f.name, id_attribute))
-                if stranded != "no" and f.iv.strand == ".":
+                if stranded and f.iv.strand == ".":
                     raise ValueError(
                             "Feature %s at %s does not have strand information but you are "
                             "using stranded mode. Try with unstrnded mode." %


### PR DESCRIPTION
Hi! I noticed that `htseq-count` was throwing an exception caused by missing strand information even when run with `--stranded=no`.

I believe that this is because the `stranded` parameter in `make_feature_genomicarrayofsets` has default value `'no'` and is used as a `str` type, but when the function is called, a `bool` type is passed in. For example, see [count.py](https://github.com/htseq/htseq/blob/7350ed323b40b33d6fd2f9d0b54764591c532931/python3/HTSeq/scripts/count.py#L380) and [count_with_barcodes.py](https://github.com/htseq/htseq/blob/7350ed323b40b33d6fd2f9d0b54764591c532931/python3/HTSeq/scripts/count_with_barcodes.py#L396). This prevents the use of htseq in unstranded mode because the comparison `stranded != 'no'` returns `True` when `stranded` is `False`. This PR changes the default value of `stranded` to `False` and changes the string comparison to a boolean condition.