### PR TITLE
Support path-like objects (`pathlib.Path` and others)

### DIFF
--- a/HTSeq/__init__.py
+++ b/HTSeq/__init__.py
@@ -874,7 +874,7 @@ class BAM_Reader(object):
         '''Parser for SAM/BAM/CRAM files, a thin layer over pysam.AlignmentFile.
 
         Arguments:
-           filename (str): The path to the input file to read
+           filename (str, Path): The path to the input file to read
            check_sq (bool): check if SQ entries are present in header
         '''
 

--- a/HTSeq/utils.py
+++ b/HTSeq/utils.py
@@ -34,14 +34,19 @@ class FileOrSequence:
     def __enter__(self):
         try:
             fos = os.fspath(self.fos)
+            fos_is_path = True
+        except TypeError:
+            # assumed to be a file handle
+            lines = self.fos
+            fos_is_path = False
+        
+        if fos_is_path:
+            self.should_close = True
             if fos.lower().endswith((".gz", ".gzip")):
                 lines = gzip.open(self.fos, 'rt')
             else:
                 lines = open(self.fos)
-            self.should_close = True
-        except TypeError:
-            # must be an open file handle
-            lines = self.fos
+
         self.lines = lines
         return self
 

--- a/HTSeq/utils.py
+++ b/HTSeq/utils.py
@@ -9,7 +9,7 @@ from HTSeq._HTSeq import *
 from HTSeq._version import __version__
 
 
-class FileOrSequence(object):
+class FileOrSequence:
     """ The construcutor takes one argument, which may either be a string,
     which is interpreted as a file name (possibly with path), or a
     connection, by which we mean a text file opened for reading, or
@@ -27,22 +27,26 @@ class FileOrSequence(object):
 
     def __init__(self, filename_or_sequence):
         self.fos = filename_or_sequence
+        self.should_close = False
         self.line_no = None
         self.lines = None
 
     def __enter__(self):
-        if isinstance(self.fos, str):
-            if self.fos.lower().endswith((".gz", ".gzip")):
+        try:
+            fos = os.fspath(self.fos)
+            if fos.lower().endswith((".gz", ".gzip")):
                 lines = gzip.open(self.fos, 'rt')
             else:
                 lines = open(self.fos)
-        else:
+            self.should_close = True
+        except TypeError:
+            # must be an open file handle
             lines = self.fos
         self.lines = lines
         return self
 
     def __exit__(self, type, value, traceback):
-        if isinstance(self.fos, str):
+        if self.should_close:
             self.lines.close()
         self.lines = None
 

--- a/test/test_parsers.py
+++ b/test/test_parsers.py
@@ -91,6 +91,24 @@ def test_open_handle_reading(data_folder):
     print('Test passed')
 
 
+def test_unreadable_object_reading():
+    unreadable_object = object()
+
+    print('Test BAM reader with unreadable object')
+    with pytest.raises(TypeError):
+        reader = HTSeq.BAM_Reader(unreadable_object)
+        for read in reader:
+            pass
+    print('Test passed')
+
+    print('Test BAM reader with unreadable object, context manager')
+    with pytest.raises(TypeError):
+        with HTSeq.BAM_Reader(unreadable_object) as reader:
+            for read in reader:
+                pass
+    print('Test passed')
+
+
 def test_bam_reader(data_folder):
     print('Test BAM reader')
     bamfile = HTSeq.BAM_Reader(data_folder+"yeast_RNASeq_excerpt.sam")

--- a/test/test_parsers.py
+++ b/test/test_parsers.py
@@ -3,6 +3,7 @@ import sys
 import os
 import glob
 import distutils.util
+from pathlib import Path
 
 build_dir = "build/lib.%s-%s" % (distutils.util.get_platform(), sys.version[0:3])
 
@@ -61,6 +62,31 @@ def test_fastq_parser(data_folder):
     with gzip.open(data_folder+'fastqExgzip.fastq.gz', 'rt') as fraw:
         f = HTSeq.FastqReader(fraw)
         for seq in f:
+            pass
+    print('Test passed')
+
+
+def test_path_like_reading(data_folder):
+    data_file = Path(data_folder) / 'yeast_RNASeq_excerpt.sam'
+    print('Test BAM reader with pathlib.Path')
+    bamfile = HTSeq.BAM_Reader(data_file)
+    for read in bamfile:
+        pass
+    print('Test passed')
+
+    print('Test BAM reader (with statement) with pathlib.Path')
+    with HTSeq.BAM_Reader(data_file) as f:
+        for read in f:
+            pass
+    print('Test passed')
+
+
+def test_open_handle_reading(data_folder):
+    data_file = Path(data_folder) / 'yeast_RNASeq_excerpt.sam'
+    print('Test BAM reader with open handle')
+    with open(data_file) as f:
+        reader = HTSeq.BAM_Reader(f)
+        for read in reader:
             pass
     print('Test passed')
 


### PR DESCRIPTION
As per [PEP 519](https://www.python.org/dev/peps/pep-0519/), Python 3.6 includes a protocol to specify that an object is "path-like", and builtin/standard library code has been updated to handle anything with a `__fspath__` attribute (including `pathlib.Path` objects and the `DirEntry` objects returned by `os.scandir`). Most notably, the `__builtins__.open` function can now be given anything path-like, in addition to `gzip.open` as used in this package.

HTSeq currently assumes that any input to a I/O function is either a `str` or an open file handle -- adjust this by trying to call `os.fspath` to convert to `str`. If this fails, then the input is assumed to already be an open file handle.