### PR TITLE
Ignore __pycache__/ everywhere, not just in HTSeq/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,11 +4,11 @@ build/
 dist/
 wheelhouse/
 .eggs/
+__pycache__/
 
 # Data and machine-generated
 HTSeq/StepVector.py
 HTSeq/_version.py
-HTSeq/__pycache__/
 src/_HTSeq.c
 src/StepVector_wrap.cxx
 example_data/minus.wig


### PR DESCRIPTION
Running the test suite locally via `pytest` leaves a `test/__pycache__` directory that wasn't previously ignored. The contents of a `__pycache__` directory should definitely never be committed, so ignore this everywhere.