### PR TITLE
Make sure IDs of ambiguous features are always in the same order

### DIFF
--- a/HTSeq/scripts/count.py
+++ b/HTSeq/scripts/count.py
@@ -262,7 +262,7 @@ def count_reads_single_file(
                     empty += 1
                 elif len(fs) > 1:
                     write_to_samout(
-                            r, "__ambiguous[" + '+'.join(fs) + "]",
+                            r, "__ambiguous[" + '+'.join(sorted(fs)) + "]",
                             samoutfile,
                             template)
                     ambiguous += 1


### PR DESCRIPTION
This fixes issue of htseq-count that reports IDs of ambiguous features not in consistent order, which causes downstream problems for users that are not aware of this behavior.

e.g. two read pairs that align to the same genes can be reported in output .sam file as:
pair1 : .... XF:Z:__ambiguous[ENSG00000197785+ENSG00000160072]
pair2: .... XF:Z:__ambiguous[ENSG00000160072+ENSG00000197785]