### PR TITLE
#63 - give warning if no contigs in common between bam/GFF

### DIFF
--- a/HTSeq/scripts/count_features/count_features_per_file.py
+++ b/HTSeq/scripts/count_features/count_features_per_file.py
@@ -101,6 +101,15 @@ def count_reads_single_file(
             order=order,
             max_buffer_size=max_buffer_size,
         )
+
+        bam_contigs = read_io_obj.get_bam_contigs()
+        if bam_contigs is not None:
+            feature_contigs = set(features.chrom_vectors.keys())
+            if not (bam_contigs & feature_contigs):
+                sys.stderr.write("Alignment file '%s' has no contigs in common with GFF/feature file. This will result "
+                                 "in zero feature counts. Please check the references match, they can often vary "
+                                 "eg using 'chr1' vs '1' as chromosome names\n" % sam_filename)
+
     except:
         sys.stderr.write("Error occurred when reading beginning of SAM/BAM file.\n")
         raise

--- a/HTSeq/scripts/count_features/reads_io_processor.py
+++ b/HTSeq/scripts/count_features/reads_io_processor.py
@@ -72,6 +72,18 @@ class ReadsIO(object):
         else:
             self.read_seq_file = HTSeq.BAM_Reader(sam_filename)
 
+    def get_bam_contigs(self):
+        """ Reads BAM header and returns a set of contigs, or None if no SQ in header """
+        contigs = None
+        sq = self.read_seq_file.get_header_dict().get("SQ")
+        if sq is not None:
+            contigs = set()
+            for sq_record in sq:
+                sn = sq_record.get("SN")
+                if sn:
+                    contigs.add(sn)
+        return contigs
+
     def _set_read_seq(
         self,
         supplementary_alignment_mode,


### PR DESCRIPTION
PR for suggestion in https://github.com/htseq/htseq/issues/63

I decided to go with a stderr warning rather than die. Feel free to change the wording as you see fit.

Example output:

```
htseq-count SRR001432_head_sorted.bam bamfile_no_qualities.gtf
2358 GFF lines processed.
Alignment file 'SRR001432_head_sorted.bam' has no contigs in common with GFF/feature file. This will result in zero feature counts. Please check the references match, they can often vary eg using 'chr1' vs '1' as chromosome names
```