### PR TITLE
Add Support for Multiple Feature Types

### DIFF
--- a/HTSeq/features.py
+++ b/HTSeq/features.py
@@ -239,8 +239,9 @@ def make_feature_dict(
     Args:
         feature_sequence (iterable of Feature): A sequence of features, e.g. as
             obtained from GFF_reader('myfile.gtf')
-        feature_type (string or None): If None, collect all features. If a
-            string, restrict to only one type of features, e.g. 'exon'.
+        feature_type (string, sequence of strings, or None): If None, collect
+            all features. If a string, restrict to only one type of features, e.g. 'exon'. If a sequence of strings, restrict to the types found
+            in the sequence, e.g. 'gene' and 'pseudogene'
         feature_query (string or None): If None, all features of the selected
             types will be collected. If a string, it has to be in the format:
 
@@ -280,7 +281,7 @@ def make_feature_dict(
 
     features = {}
     for f in feature_sequence:
-        if feature_type in (None, f.type):
+        if any(ft in (None, f.type) for ft in feature_type):
             if f.type not in features:
                 features[f.type] = {}
             res_ftype = features[f.type]
@@ -322,8 +323,10 @@ def make_feature_genomicarrayofsets(
             attributes, separated by colons (:), will be used as an identifier.
             For instance, ['gene_id', 'exon_number'] uniquely identifies
             specific exons.
-        feature_type (string or None): If None, collect all features. If a
-            string, restrict to only one type of features, e.g. 'exon'.
+        feature_type (string, sequence of strings, or None): If None, collect
+            all features. If a string, restrict to only one type of features,
+            e.g. 'exon'. If a sequence of strings, restrict to the types found
+            in the sequence, e.g. 'gene' and 'pseudogene'
         feature_query (string or None): If None, all features of the selected
             types will be collected. If a string, it has to be in the format:
 
@@ -401,7 +404,7 @@ def make_feature_genomicarrayofsets(
     i = 0
     try:
         for f in feature_sequence:
-            if feature_type in (None, f.type):
+            if any(ft in (None, f.type) for ft in feature_type):
                 feature_id = get_id_attr(f, id_attribute)
 
                 if stranded and f.iv.strand == ".":

--- a/HTSeq/scripts/count.py
+++ b/HTSeq/scripts/count.py
@@ -274,10 +274,13 @@ def _parse_sanitize_cmdline_arguments():
         "--type",
         type=str,
         dest="feature_type",
-        default="exon",
+        action="append",
+        default=["exon"],
         help="Feature type (3rd column in GTF file) to be used, "
-        + "all features of other type are ignored (default, suitable for Ensembl "
-        + "GTF files: exon)",
+        + "all features of other type are ignored (default, suitable for"
+        + "Ensembl GTF files: exon). You can call this option multiple times. "
+        + "Features of all specified types will be included. E.g. to include "
+        + "both genes and pseudogenes you might use -t gene -t pseudogene",
     )
     pa.add_argument(
         "-i",

--- a/doc/htseqcount.rst
+++ b/doc/htseqcount.rst
@@ -196,8 +196,11 @@ Options
 
    Feature type (3rd column in GTF file) to be used, all
    features of other type are ignored (default, suitable
-   for RNA-Seq analysis using an `Ensembl GTF`_ file: ``exon``)
-   
+   for RNA-Seq analysis using an `Ensembl GTF`_ file: ``exon``).
+   You can call this option multiple times. Features of all
+   specified types will be included. E.g. to include both genes
+   and pseudogenes you might use -t gene -t pseudogene.
+
 .. _`Ensembl GTF`: http://mblab.wustl.edu/GTF22.html
 
 .. cmdoption:: -i <id attribute>, --idattr=<id attribute>


### PR DESCRIPTION
I have implemented support to choose features of multiple types in htseq-count. This can be done by using the `type` argument multiple times: `-t gene -t pseudogene`.
To achieve this I changed the `type` argument to a list of strings, with `["exon"]` being the default. Apart from updating the documentation, I only had to adjust the logic that checks for feature type in two places: `make_feature_dict()` and `make_feature_genomicarrayofsets()`.

I am happy to do more work on this if required. Just let me know.