### PR TITLE
Give CI / Build Workflow Read Access to Repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: Build
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build_manylinux:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   build_manylinux:


### PR DESCRIPTION
The changes in this PR come from a hunch that the `build_manylinux` jobs were failing because of missing permissions to checkout the repository.

I'm keeping the PR as a draft until it passes checks.