### PR TITLE
fix(setup): `numpy` included in `setup_requires`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel", "numpy", "Cython"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -78,48 +78,6 @@ kwargs = dict(
     },
   )
 
-try:
-    import numpy
-except ImportError:
-    sys.stderr.write("Setup script for HTSeq: Failed to import 'numpy'.\n")
-    sys.stderr.write("Please install numpy and then try again to install" +
-                     " HTSeq.\n")
-    sys.exit(1)
-
-
-numpy_include_dir = os.path.join(
-        os.path.dirname(numpy.__file__),
-        'core',
-        'include',
-        )
-
-
-#def get_include_dirs(cpp=False):
-#    '''OSX 10.14 and later split the /usr/include contents everywhere'''
-#    include_dirs = []
-#    if sys.platform != 'darwin':
-#        return include_dirs
-#
-#    paths = {
-#        'C': [
-#            '/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/',
-#        ],
-#        'C++': [
-#            '/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/',
-#        ],
-#    }
-#
-#    for path in paths['C']:
-#        if os.path.isdir(path):
-#            include_dirs.append(path)
-#    if cpp:
-#        for path in paths['C++']:
-#            if os.path.isdir(path):
-#                include_dirs.append(path)
-#
-#    return include_dirs
-
-
 def get_library_dirs_cpp():
     '''OSX 10.14 and later messed up C/C++ library locations'''
     if sys.platform == 'darwin':
@@ -200,6 +158,16 @@ class Build_with_preprocess(build_py):
         build_py.run(self)
 
 
+def lazy_numpy_include_dir():
+    """Lazily obtain NumPy include directory."""
+    try:
+        import numpy
+        return os.path.join(os.path.dirname(numpy.__file__), 'core', 'include')
+    except ImportError:
+        sys.stderr.write("Failed to import 'numpy'. It is required for building HTSeq.\n")
+        sys.exit(1)
+
+
 setup(name='HTSeq',
       version=version,
       author='Simon Anders, Fabio Zanini',
@@ -225,7 +193,7 @@ setup(name='HTSeq',
          Extension(
              'HTSeq._HTSeq',
              ['src/_HTSeq.c'],
-             include_dirs=[numpy_include_dir],#+get_include_dirs(),
+             include_dirs=[lazy_numpy_include_dir()],#+get_include_dirs(),
              extra_compile_args=['-w']),
          Extension(
              'HTSeq._StepVector',


### PR DESCRIPTION
Since numpy is already included in `setup_requires`, https://github.com/htseq/htseq/blob/c111d906c914a346e8c25c880139ca07cbb872a8/setup.py#L63
the `import numpy` should not be necessary at the top-level of `setup.py`; however, it can break package managers (in my case poetry) when numpy happens not to be installed in, for example, a virtual environment in sequence prior to installing HTSeq.

This PR adds a `pyproject.toml` to render HTSeq compliant with [PEP 518](https://peps.python.org/pep-0518/).

