### PR TITLE
Replace deprecated distutils with sysconfig

### DIFF
--- a/test/test_general.py
+++ b/test/test_general.py
@@ -2,9 +2,9 @@ import pytest
 import sys
 import os
 import glob
-import distutils.util
+import sysconfig
 
-build_dir = "build/lib.%s-%s" % (distutils.util.get_platform(), sys.version[0:3])
+build_dir = "build/lib.%s-%s" % (sysconfig.get_platform(), sys.version[0:3])
 sys.path.insert(0, os.path.join(os.getcwd(), build_dir))
 
 

--- a/test/test_genomic.py
+++ b/test/test_genomic.py
@@ -2,13 +2,13 @@ import pytest
 import sys
 import os
 import glob
-import distutils.util
+import sysconfig
 from pathlib import Path
 import unittest
 import pytest
 import conftest
 
-build_dir = "build/lib.%s-%s" % (distutils.util.get_platform(), sys.version[0:3])
+build_dir = "build/lib.%s-%s" % (sysconfig.get_platform(), sys.version[0:3])
 
 sys.path.insert(0, os.path.join(os.getcwd(), build_dir))
 import HTSeq

--- a/test/test_parsers.py
+++ b/test/test_parsers.py
@@ -2,10 +2,10 @@ import pytest
 import sys
 import os
 import glob
-import distutils.util
+import sysconfig
 from pathlib import Path
 
-build_dir = "build/lib.%s-%s" % (distutils.util.get_platform(), sys.version[0:3])
+build_dir = "build/lib.%s-%s" % (sysconfig.get_platform(), sys.version[0:3])
 
 sys.path.insert(0, os.path.join(os.getcwd(), build_dir))
 import HTSeq

--- a/test/test_stretch_vector.py
+++ b/test/test_stretch_vector.py
@@ -3,13 +3,13 @@ import numpy as np
 import sys
 import os
 import glob
-import distutils.util
+import sysconfig
 from pathlib import Path
 import unittest
 import pytest
 import conftest
 
-build_dir = "build/lib.%s-%s" % (distutils.util.get_platform(), sys.version[0:3])
+build_dir = "build/lib.%s-%s" % (sysconfig.get_platform(), sys.version[0:3])
 
 sys.path.insert(0, os.path.join(os.getcwd(), build_dir))
 import HTSeq

--- a/test/tss_test.py
+++ b/test/tss_test.py
@@ -1,9 +1,9 @@
 import os
 import sys
-import distutils.util
+import sysconfig
 import numpy
 
-build_dir = "build/lib.%s-%s" % (distutils.util.get_platform(), sys.version[0:3])
+build_dir = "build/lib.%s-%s" % (sysconfig.get_platform(), sys.version[0:3])
 
 sys.path.insert(0, os.path.join(os.getcwd(), build_dir))
 import HTSeq


### PR DESCRIPTION
Hi there. Thanks for developing this great library.
I tried to test this library with Python 3.12 and noticed that `distutils` is used in the test code.

As you know, `distutils` [has been removed](https://docs.python.org/ja/3.10/whatsnew/3.10.html#distutils-deprecated) as of Python 3.12. 
It is recommended to use `sysconfig.get_platform` instead of the deprecated `distutils.util.get_platform`.
e.g. https://github.com/pypa/wheel/pull/428

With this change, I have confirmed that all tests pass even with Python 3.12.