### PR TITLE
fix multiprocesses issue on Mac

### DIFF
--- a/buildwheels.sh
+++ b/buildwheels.sh
@@ -24,6 +24,7 @@ for PYBIN in ${PYBINS}; do
     echo "Install requirements..."
     ${PYBIN}/pip install setuptools wheel Cython Pillow matplotlib pandas
     ${PYBIN}/pip install -r /io/requirements.txt
+    ${PYBIN}/pip install HTseq
 
     echo "Build wheels..."
     ${PYBIN}/pip wheel /io/ -w wheelhouse/

--- a/buildwheels.sh
+++ b/buildwheels.sh
@@ -24,7 +24,6 @@ for PYBIN in ${PYBINS}; do
     echo "Install requirements..."
     ${PYBIN}/pip install setuptools wheel Cython Pillow matplotlib pandas
     ${PYBIN}/pip install -r /io/requirements.txt
-    ${PYBIN}/pip install HTseq
 
     echo "Build wheels..."
     ${PYBIN}/pip wheel /io/ -w wheelhouse/

--- a/scripts/htseq-count
+++ b/scripts/htseq-count
@@ -2,5 +2,5 @@
 
 import HTSeq.scripts.count
 
-if "__name__" == "__main__":
+if __name__ == "__main__":
     HTSeq.scripts.count.main()

--- a/scripts/htseq-count
+++ b/scripts/htseq-count
@@ -2,4 +2,5 @@
 
 import HTSeq.scripts.count
 
-HTSeq.scripts.count.main()
+if "__name__" == "__main__":
+    HTSeq.scripts.count.main()

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ import os
 import sys
 from setuptools import setup, Command, Extension
 from setuptools.command.build_py import build_py
+import numpy
 
 
 this_directory = os.path.abspath(os.path.dirname(__file__))
@@ -193,7 +194,8 @@ setup(name='HTSeq',
          Extension(
              'HTSeq._HTSeq',
              ['src/_HTSeq.c'],
-             include_dirs=[lazy_numpy_include_dir()],#+get_include_dirs(),
+             #include_dirs=[lazy_numpy_include_dir()],#+get_include_dirs(),
+             include_dirs=[numpy.get_include()],
              extra_compile_args=['-w']),
          Extension(
              'HTSeq._StepVector',

--- a/src/HTSeq/_HTSeq.pyx
+++ b/src/HTSeq/_HTSeq.pyx
@@ -1168,7 +1168,7 @@ cdef class Sequence(object):
 
     cpdef object add_bases_to_count_array(Sequence self, numpy.ndarray count_array_):
 
-        cdef numpy.ndarray[numpy.int32_t, ndim = 2] count_array = count_array_
+        cdef numpy.ndarray[numpy.int64_t, ndim = 2] count_array = count_array_
         cdef int seq_length = len(self.seq)
 
         if numpy.PyArray_DIMS(count_array)[0] < seq_length:
@@ -1383,7 +1383,7 @@ cdef class SequenceWithQualities(Sequence):
     cpdef object add_qual_to_count_array(SequenceWithQualities self,
                                          numpy.ndarray count_array_):
 
-        cdef numpy.ndarray[numpy.int32_t, ndim = 2] count_array = count_array_
+        cdef numpy.ndarray[numpy.int64_t, ndim = 2] count_array = count_array_
         if self._qualarr is None:
             self._fill_qual_arr()
         cdef numpy.ndarray[numpy.uint8_t, ndim = 1] qual_array = self._qualarr

--- a/src/HTSeq/_HTSeq.pyx
+++ b/src/HTSeq/_HTSeq.pyx
@@ -1168,7 +1168,7 @@ cdef class Sequence(object):
 
     cpdef object add_bases_to_count_array(Sequence self, numpy.ndarray count_array_):
 
-        cdef numpy.ndarray[dtype = numpy.int_t, ndim = 2] count_array = count_array_
+        cdef numpy.ndarray[numpy.int32_t, ndim = 2] count_array = count_array_
         cdef int seq_length = len(self.seq)
 
         if numpy.PyArray_DIMS(count_array)[0] < seq_length:
@@ -1383,7 +1383,7 @@ cdef class SequenceWithQualities(Sequence):
     cpdef object add_qual_to_count_array(SequenceWithQualities self,
                                          numpy.ndarray count_array_):
 
-        cdef numpy.ndarray[dtype = numpy.int_t, ndim = 2] count_array = count_array_
+        cdef numpy.ndarray[numpy.int32_t, ndim = 2] count_array = count_array_
         if self._qualarr is None:
             self._fill_qual_arr()
         cdef numpy.ndarray[numpy.uint8_t, ndim = 1] qual_array = self._qualarr

--- a/src/HTSeq/_HTSeq.pyx
+++ b/src/HTSeq/_HTSeq.pyx
@@ -1168,7 +1168,7 @@ cdef class Sequence(object):
 
     cpdef object add_bases_to_count_array(Sequence self, numpy.ndarray count_array_):
 
-        cdef numpy.ndarray[numpy.int_t, ndim = 2] count_array = count_array_
+        cdef numpy.ndarray[dtype = numpy.int_t, ndim = 2] count_array = count_array_
         cdef int seq_length = len(self.seq)
 
         if numpy.PyArray_DIMS(count_array)[0] < seq_length:
@@ -1383,7 +1383,7 @@ cdef class SequenceWithQualities(Sequence):
     cpdef object add_qual_to_count_array(SequenceWithQualities self,
                                          numpy.ndarray count_array_):
 
-        cdef numpy.ndarray[numpy.int_t, ndim = 2] count_array = count_array_
+        cdef numpy.ndarray[dtype = numpy.int_t, ndim = 2] count_array = count_array_
         if self._qualarr is None:
             self._fill_qual_arr()
         cdef numpy.ndarray[numpy.uint8_t, ndim = 1] qual_array = self._qualarr


### PR DESCRIPTION
Hi, I just looked around on the internet and found a post about "freeze_support" issue using `multiprocess` on Mac: https://stackoverflow.com/questions/60691363/runtimeerrorfreeze-support-on-mac

To avoid this error, simply put the count function under a `if "__name__" == "__main__"`, i.e. in the htseq-count.py I just added:

> #!/usr/bin/env python
import HTSeq.scripts.count
if \_\_name\_\_ == "\_\_main\_\_": # newly added
    HTSeq.scripts.count.main()

and it works so far well for me as I tested with the same code I used before and didn't see the error occur where it was observed.
I do not know if it is an elegant enough solution tho.

cheers!