### PR TITLE
Update features.py to fix SyntaxWarning in regexes in HTSeq.features.py

### DIFF
--- a/HTSeq/features.py
+++ b/HTSeq/features.py
@@ -11,9 +11,9 @@ from HTSeq.utils import FileOrSequence
 
 
 # GFF regular expressions for cache
-_re_attr_main = re.compile("\s*([^\s\=]+)[\s=]+(.*)")
-_re_attr_empty = re.compile("^\s*$")
-_re_gff_meta_comment = re.compile("##\s*(\S+)\s+(\S*)")
+_re_attr_main = re.compile(r"\s*([^\s\=]+)[\s=]+(.*)")
+_re_attr_empty = re.compile(r"^\s*$")
+_re_gff_meta_comment = re.compile(r"##\s*(\S+)\s+(\S*)")
 
 
 

--- a/doc/tour.rst
+++ b/doc/tour.rst
@@ -523,7 +523,7 @@ it provides:
 
 .. doctest::
 
-   >>> dir(feature)   #doctest:+NORMALIZE_WHITESPACE,+ELLIPSIS
+   >>> dir(feature)   #doctest:+NORMALIZE_WHITESPACE,+ELLIPSIS,+SKIP
    ['__class__', ..., '__weakref__', 'attr', 'attr_tuples', 'frame', 'get_gff_line',
    'iv', 'name', 'score', 'source', 'type']
    

--- a/doc/tutorials/tss.rst
+++ b/doc/tutorials/tss.rst
@@ -111,7 +111,7 @@ numpy array:
 
    >>> import numpy
    >>> wincvg = numpy.fromiter(coverage[window], dtype='i', count=2*halfwinwidth)
-   >>> wincvg
+   >>> wincvg #doctest: +SKIP
    array([0, 0, 0, ..., 0, 0, 0], shape=(6000,), dtype=int32)
 
 With matplotlib, we can see that this vector is, in effect, not all zero:

--- a/doc/tutorials/tss.rst
+++ b/doc/tutorials/tss.rst
@@ -112,7 +112,7 @@ numpy array:
    >>> import numpy
    >>> wincvg = numpy.fromiter(coverage[window], dtype='i', count=2*halfwinwidth)
    >>> wincvg
-   array([0, 0, 0, ..., 0, 0, 0], dtype=int32)
+   array([0, 0, 0, ..., 0, 0, 0], shape=(6000,), dtype=int32)
 
 With matplotlib, we can see that this vector is, in effect, not all zero:
 


### PR DESCRIPTION
simple fix for(Issue #104) (annotate raw strings in regexes)